### PR TITLE
fix(detail-dosen): correct typo in Scholar ID label

### DIFF
--- a/src/modules/dppm/feature/dosen/components/detail-dosen.tsx
+++ b/src/modules/dppm/feature/dosen/components/detail-dosen.tsx
@@ -40,7 +40,7 @@ export default function DetailDosen({ dosen }: { dosen: IDosen }) {
           <TableCell>{dosen?.job_functional}</TableCell>
         </TableRow>
         <TableRow>
-          <TableHead className='border-r'>Shrolar ID </TableHead>
+          <TableHead className='border-r'>Scholar ID </TableHead>
           <TableCell>{dosen?.scholar_id}</TableCell>
         </TableRow>
         <TableRow>


### PR DESCRIPTION
The label "Shrolar ID" was misspelled and has been corrected to "Scholar ID" to ensure consistency and accuracy in the UI.