### PR TITLE
fix: correct typo in Scholar ID label

### DIFF
--- a/src/modules/kaprodi/feature/dosen/components/detail-dosen.tsx
+++ b/src/modules/kaprodi/feature/dosen/components/detail-dosen.tsx
@@ -40,7 +40,7 @@ export default function DetailDosen({ dosen }: { dosen: IDosen }) {
           <TableCell>{dosen?.job_functional}</TableCell>
         </TableRow>
         <TableRow>
-          <TableHead className='border-r'>Shrolar ID </TableHead>
+          <TableHead className='border-r'>Scholar ID </TableHead>
           <TableCell>{dosen?.scholar_id}</TableCell>
         </TableRow>
         <TableRow>


### PR DESCRIPTION
Fix a typo in the label "Shrolar ID" to "Scholar ID" for consistency and clarity in the DetailDosen component.