### PR TITLE
refactor(penelitian-page-dosen): exclude scholar_id and scopus_id 

### DIFF
--- a/src/modules/dosen/feature/penelitian/penelitian-page-dosen.tsx
+++ b/src/modules/dosen/feature/penelitian/penelitian-page-dosen.tsx
@@ -47,10 +47,12 @@ export default function PenelitianDosenPage() {
   if (!user) return null
 
   const isNull = Object.fromEntries(
-    Object.entries(user as Dosen).map(([key, value]) => [
-      key,
-      value === null || value === "",
-    ]),
+    Object.entries(user as Dosen)
+      .filter(([key]) => key !== "scholar_id" && key !== "scopus_id")
+      .map(([key, value]) => [
+        key,
+        value === null || value === "",
+      ]),
   )
 
   return (


### PR DESCRIPTION
from null check

Filter out scholar_id and scopus_id fields before performing null check to avoid unnecessary validation on these optional fields