### PR TITLE
refactor(api): change profile update from post to put method

### DIFF
--- a/src/modules/dppm/dashboard.service.ts
+++ b/src/modules/dppm/dashboard.service.ts
@@ -1,6 +1,6 @@
 import { UserType } from "@/schema/user"
 import { API_ENDPOINTS, API_ENDPOINTS_DPPM } from "@/services/api/api-config"
-import { getData, postData } from "@/services/api/http"
+import { getData, postData, putData } from "@/services/api/http"
 import { ResponseDownload } from "../kaprodi/kaprodi.interface"
 import { DppmDashboardResopnse, DppmResponse } from "./dashboard.interface"
 
@@ -12,7 +12,7 @@ export async function getDashboard() {
 }
 
 export async function updateProfile(data: UserType) {
-  const response: DppmResponse<UserType> = await postData(
+  const response: DppmResponse<UserType> = await putData(
     API_ENDPOINTS.PROFILE,
     data,
   )

--- a/src/modules/keuangan/keuangan.service.ts
+++ b/src/modules/keuangan/keuangan.service.ts
@@ -3,7 +3,7 @@ import {
   API_ENDPOINTS,
   API_ENDPOINTS_KEUANGAN,
 } from "@/services/api/api-config"
-import { getData, postData } from "@/services/api/http"
+import { getData, postData, putData } from "@/services/api/http"
 import { ResponseDownload } from "../kaprodi/kaprodi.interface"
 import { KeuanganDashboard, KeuanganResponse } from "./keuangan.interface"
 
@@ -15,7 +15,7 @@ export async function getDashboard() {
 }
 
 export async function updateProfile(data: UserType) {
-  const response: KeuanganResponse<UserType> = await postData(
+  const response: KeuanganResponse<UserType> = await putData(
     API_ENDPOINTS.PROFILE,
     data,
   )


### PR DESCRIPTION
Update HTTP method for profile updates to use PUT instead of POST to better reflect REST conventions for update operations. Changes made in both keuangan and dppm services.