### PR TITLE
feat(dashboard): add edit pages for returned research and service

### DIFF
--- a/src/app/(setup)/dashboard/dosen/penelitian/edit/dikembalikan/[id]/page.tsx
+++ b/src/app/(setup)/dashboard/dosen/penelitian/edit/dikembalikan/[id]/page.tsx
@@ -1,0 +1,14 @@
+"use client"
+import ComingSoon from "@/components/molecules/coming-soon"
+import { useRequiredAuth } from "@/hooks/use-required-auth"
+import { useParams } from "next/navigation"
+
+export default function EditPage() {
+  const { user } = useRequiredAuth()
+  const { id } = useParams()
+
+  if (!id || !user) {
+    return null
+  }
+  return <ComingSoon />
+}

--- a/src/app/(setup)/dashboard/dosen/pengabdian/edit/dikembalikan/[id]/page.tsx
+++ b/src/app/(setup)/dashboard/dosen/pengabdian/edit/dikembalikan/[id]/page.tsx
@@ -1,0 +1,14 @@
+"use client"
+import ComingSoon from "@/components/molecules/coming-soon"
+import { useRequiredAuth } from "@/hooks/use-required-auth"
+import { useParams } from "next/navigation"
+
+export default function EditPage() {
+  const { user } = useRequiredAuth()
+  const { id } = useParams()
+
+  if (!id || !user) {
+    return null
+  }
+  return <ComingSoon />
+}


### PR DESCRIPTION
Add placeholder edit pages for returned research and service submissions that show a coming soon message. These pages include authentication and parameter checks.