### PR TITLE
fix(table): update row numbering to consider pagination in multiple

### DIFF
--- a/src/modules/dosen/feature/penelitian/components/column-penelitian.tsx
+++ b/src/modules/dosen/feature/penelitian/components/column-penelitian.tsx
@@ -22,7 +22,14 @@ export const columnPenelitian = ({
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "action",

--- a/src/modules/dosen/feature/pengabdian/components/column-pengabdian.tsx
+++ b/src/modules/dosen/feature/pengabdian/components/column-pengabdian.tsx
@@ -22,7 +22,14 @@ export const columnPengabdian = ({
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "action",

--- a/src/modules/dosen/feature/publikasi/components/column-publikasi.tsx
+++ b/src/modules/dosen/feature/publikasi/components/column-publikasi.tsx
@@ -29,7 +29,14 @@ export const columnPublikasi = ({
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "action",

--- a/src/modules/dppm/feature/dosen/components/column-dosen.tsx
+++ b/src/modules/dppm/feature/dosen/components/column-dosen.tsx
@@ -12,43 +12,50 @@ interface ColumnDosenProps {
 }
 
 export const columnDosen = ({
-  refetch,
+  refetch
 }: ColumnDosenProps): ColumnDef<IDosen>[] => {
   return [
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>,
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "nidn",
       accessorKey: "nidn",
-      header: "NIDN",
+      header: "NIDN"
     },
     {
       id: "name",
       accessorKey: "name",
-      header: "Nama",
+      header: "Nama"
     },
     {
       id: "name_with_title",
       accessorKey: "name_with_title",
-      header: "Nama dengan Gelar",
+      header: "Nama dengan Gelar"
     },
     {
       id: "email",
       accessorKey: "email",
-      header: "Email",
+      header: "Email"
     },
     {
       id: "prodi",
       accessorKey: "prodi",
-      header: "Prodi",
+      header: "Prodi"
     },
     {
       id: "affiliate_campus",
       accessorKey: "affiliate_campus",
-      header: "Afiliasi",
+      header: "Afiliasi"
     },
     {
       id: "is_active",
@@ -66,7 +73,7 @@ export const columnDosen = ({
               className={cn("p-2 hover:text-primary-foreground", {
                 "border-green-500 text-green-500 hover:bg-green-500":
                   item.is_active,
-                "border-red-500 text-red-500 hover:bg-red-500": !item.is_active,
+                "border-red-500 text-red-500 hover:bg-red-500": !item.is_active
               })}
             >
               {item.is_active ? (
@@ -77,7 +84,7 @@ export const columnDosen = ({
             </Badge>
           </Tooltip>
         )
-      },
+      }
     },
     {
       id: "action",
@@ -100,7 +107,7 @@ export const columnDosen = ({
             </Modal>
           </span>
         )
-      },
-    },
+      }
+    }
   ]
 }

--- a/src/modules/dppm/feature/fakultas/components/column-fakultas.tsx
+++ b/src/modules/dppm/feature/fakultas/components/column-fakultas.tsx
@@ -24,9 +24,13 @@ export const columnFakultas = ({ refetch }: Props): ColumnDef<IFakultas>[] => {
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => {
-        const index = row.index + 1
-        return <span>{index}</span>
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
       }
     },
     {

--- a/src/modules/dppm/feature/kaprodi/components/column-kaprodi.tsx
+++ b/src/modules/dppm/feature/kaprodi/components/column-kaprodi.tsx
@@ -34,9 +34,13 @@ export const columnKaprodi = ({
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => {
-        const index = row.index + 1
-        return <span>{index}</span>
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
       }
     },
     {

--- a/src/modules/dppm/feature/penelitian/components/column-penelitian.tsx
+++ b/src/modules/dppm/feature/penelitian/components/column-penelitian.tsx
@@ -13,7 +13,14 @@ export const columnPenelitian = (): ColumnDef<PenelitianDosen>[] => {
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>,
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "action",
@@ -27,34 +34,34 @@ export const columnPenelitian = (): ColumnDef<PenelitianDosen>[] => {
               href={`${ROUTE.DASHBOARD}/dppm/penelitian/${row.original.id}`}
               className={cn(
                 buttonVariants({ variant: "outline", size: "icon" }),
-                "border-cyan-500 text-cyan-500 hover:bg-cyan-500 hover:text-primary-foreground",
+                "border-cyan-500 text-cyan-500 hover:bg-cyan-500 hover:text-primary-foreground"
               )}
             >
               <InfoIcon />
             </Link>
           </Tooltip>
         )
-      },
+      }
     },
     {
       id: "title",
       accessorKey: "title",
-      header: "Judul Penelitian",
+      header: "Judul Penelitian"
     },
     {
       id: "leader",
       accessorKey: "leader",
-      header: "Penanggung Jawab",
+      header: "Penanggung Jawab"
     },
     {
       id: "academic_year",
       accessorKey: "academic_year",
-      header: "Tahun Akademik",
+      header: "Tahun Akademik"
     },
     {
       id: "created_date",
       accessorKey: "created_date",
-      header: "tanggal dibuat",
+      header: "tanggal dibuat"
     },
     {
       accessorKey: "status",
@@ -66,13 +73,13 @@ export const columnPenelitian = (): ColumnDef<PenelitianDosen>[] => {
           header: "Kaprodi",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.kaprodi} />
-          ),
+          )
         },
         {
           id: "status_dppm",
           accessorKey: "status_dppm",
           header: "Dppm",
-          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />,
+          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />
         },
         {
           id: "status_keuangan",
@@ -80,9 +87,9 @@ export const columnPenelitian = (): ColumnDef<PenelitianDosen>[] => {
           header: "Keuangan",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.keuangan} />
-          ),
-        },
-      ],
-    },
+          )
+        }
+      ]
+    }
   ]
 }

--- a/src/modules/dppm/feature/pengabdian/components/column-pengabdian.tsx
+++ b/src/modules/dppm/feature/pengabdian/components/column-pengabdian.tsx
@@ -13,7 +13,14 @@ export const columnPengabdian = (): ColumnDef<PengabdianDosen>[] => {
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>,
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "action",
@@ -27,34 +34,34 @@ export const columnPengabdian = (): ColumnDef<PengabdianDosen>[] => {
               href={`${ROUTE.DASHBOARD}/dppm/pengabdian/${row.original.id}`}
               className={cn(
                 buttonVariants({ variant: "outline", size: "icon" }),
-                "border-cyan-500 text-cyan-500 hover:bg-cyan-500 hover:text-primary-foreground",
+                "border-cyan-500 text-cyan-500 hover:bg-cyan-500 hover:text-primary-foreground"
               )}
             >
               <InfoIcon />
             </Link>
           </Tooltip>
         )
-      },
+      }
     },
     {
       id: "title",
       accessorKey: "title",
-      header: "Judul Pengabdian",
+      header: "Judul Pengabdian"
     },
     {
       id: "leader",
       accessorKey: "leader",
-      header: "Penanggung Jawab",
+      header: "Penanggung Jawab"
     },
     {
       id: "academic_year",
       accessorKey: "academic_year",
-      header: "Tahun Akademik",
+      header: "Tahun Akademik"
     },
     {
       id: "created_date",
       accessorKey: "created_date",
-      header: "tanggal dibuat",
+      header: "tanggal dibuat"
     },
     {
       accessorKey: "status",
@@ -66,13 +73,13 @@ export const columnPengabdian = (): ColumnDef<PengabdianDosen>[] => {
           header: "Kaprodi",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.kaprodi} />
-          ),
+          )
         },
         {
           id: "status_dppm",
           accessorKey: "status_dppm",
           header: "Dppm",
-          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />,
+          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />
         },
         {
           id: "status_keuangan",
@@ -80,9 +87,9 @@ export const columnPengabdian = (): ColumnDef<PengabdianDosen>[] => {
           header: "Keuangan",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.keuangan} />
-          ),
-        },
-      ],
-    },
+          )
+        }
+      ]
+    }
   ]
 }

--- a/src/modules/dppm/feature/prodi/components/coulmns-prodi.tsx
+++ b/src/modules/dppm/feature/prodi/components/coulmns-prodi.tsx
@@ -30,9 +30,13 @@ export const columnProdi = ({
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => {
-        const index = row.index + 1
-        return <span>{index}</span>
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
       }
     },
     {

--- a/src/modules/dppm/feature/publikasi/components/column-publikasi.tsx
+++ b/src/modules/dppm/feature/publikasi/components/column-publikasi.tsx
@@ -20,13 +20,20 @@ interface columnPublikasiProps {
 
 export const columnPublikasi = ({
   pubilkasi,
-  refetch,
+  refetch
 }: columnPublikasiProps): ColumnDef<PublikasiDppm>[] => {
   return [
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>,
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "action",
@@ -43,11 +50,11 @@ export const columnPublikasi = ({
           },
           onError: err => {
             toast.error(err.response?.data.message)
-          },
+          }
         })
 
         const data = pubilkasi.find(
-          publikasi => publikasi.id === row.original.id,
+          publikasi => publikasi.id === row.original.id
         )
 
         return (
@@ -63,7 +70,7 @@ export const columnPublikasi = ({
               <div className='flex flex-col gap-4 tracking-wide'>
                 {[
                   row.original.status.kaprodi,
-                  row.original.status.dppm,
+                  row.original.status.dppm
                 ].includes("rejected") && (
                   <div className='rounded-lg border border-red-500 px-4 py-2 text-red-500'>
                     <p className='text-sm capitalize'>
@@ -117,7 +124,7 @@ export const columnPublikasi = ({
                     <span className='font-medium'>Tanggal Publikasi:</span>
                     {data?.tanggal_publikasi
                       ? format(new Date(data?.tanggal_publikasi), "PPP", {
-                          locale: id,
+                          locale: id
                         })
                       : "-"}
                   </p>
@@ -140,7 +147,7 @@ export const columnPublikasi = ({
                   href={data?.link_publikasi as string}
                   className={cn(
                     buttonVariants({ variant: "default" }),
-                    "capitalize",
+                    "capitalize"
                   )}
                   target='_blank'
                 >
@@ -164,15 +171,15 @@ export const columnPublikasi = ({
               )}
           </span>
         )
-      },
+      }
     },
     {
       accessorKey: "judul",
-      header: "Judul Pengabdian",
+      header: "Judul Pengabdian"
     },
     {
       accessorKey: "author",
-      header: "Penulis",
+      header: "Penulis"
     },
     {
       accessorKey: "tanggal_publikasi",
@@ -180,15 +187,15 @@ export const columnPublikasi = ({
       cell: ({ row }) => {
         const date = new Date(row.original.tanggal_publikasi)
         return <span>{format(date, "PPP", { locale: id })}</span>
-      },
+      }
     },
     {
       accessorKey: "tahun",
-      header: "Tahun",
+      header: "Tahun"
     },
     {
       accessorKey: "jurnal",
-      header: "Jurnal",
+      header: "Jurnal"
     },
     {
       accessorKey: "status",
@@ -200,13 +207,13 @@ export const columnPublikasi = ({
           header: "Kaprodi",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.kaprodi} />
-          ),
+          )
         },
         {
           id: "status_dppm",
           accessorKey: "status_dppm",
           header: "Dppm",
-          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />,
+          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />
         },
         {
           id: "status_keuangan",
@@ -214,9 +221,9 @@ export const columnPublikasi = ({
           header: "Keuangan",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.keuangan} />
-          ),
-        },
-      ],
-    },
+          )
+        }
+      ]
+    }
   ]
 }

--- a/src/modules/kaprodi/feature/dosen/components/column-dosen.tsx
+++ b/src/modules/kaprodi/feature/dosen/components/column-dosen.tsx
@@ -36,7 +36,14 @@ export const columnDosen = ({
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "nidn",

--- a/src/modules/kaprodi/feature/penelitian/components/column-penelitian.tsx
+++ b/src/modules/kaprodi/feature/penelitian/components/column-penelitian.tsx
@@ -13,7 +13,14 @@ export const columnPenelitian = (): ColumnDef<PenelitianDosen>[] => {
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>,
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "action",
@@ -27,34 +34,34 @@ export const columnPenelitian = (): ColumnDef<PenelitianDosen>[] => {
               href={`${ROUTE.DASHBOARD}/kaprodi/penelitian/${row.original.id}`}
               className={cn(
                 buttonVariants({ variant: "outline", size: "icon" }),
-                "border-cyan-500 text-cyan-500 hover:bg-cyan-500 hover:text-primary-foreground",
+                "border-cyan-500 text-cyan-500 hover:bg-cyan-500 hover:text-primary-foreground"
               )}
             >
               <InfoIcon />
             </Link>
           </Tooltip>
         )
-      },
+      }
     },
     {
       id: "title",
       accessorKey: "title",
-      header: "Judul Penelitian",
+      header: "Judul Penelitian"
     },
     {
       id: "leader",
       accessorKey: "leader",
-      header: "Penanggung Jawab",
+      header: "Penanggung Jawab"
     },
     {
       id: "academic_year",
       accessorKey: "academic_year",
-      header: "Tahun Akademik",
+      header: "Tahun Akademik"
     },
     {
       id: "created_date",
       accessorKey: "created_date",
-      header: "tanggal dibuat",
+      header: "tanggal dibuat"
     },
     {
       accessorKey: "status",
@@ -66,13 +73,13 @@ export const columnPenelitian = (): ColumnDef<PenelitianDosen>[] => {
           header: "Kaprodi",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.kaprodi} />
-          ),
+          )
         },
         {
           id: "status_dppm",
           accessorKey: "status_dppm",
           header: "Dppm",
-          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />,
+          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />
         },
         {
           id: "status_keuangan",
@@ -80,9 +87,9 @@ export const columnPenelitian = (): ColumnDef<PenelitianDosen>[] => {
           header: "Keuangan",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.keuangan} />
-          ),
-        },
-      ],
-    },
+          )
+        }
+      ]
+    }
   ]
 }

--- a/src/modules/kaprodi/feature/pengabdian/components/column-pengabdian.tsx
+++ b/src/modules/kaprodi/feature/pengabdian/components/column-pengabdian.tsx
@@ -13,7 +13,14 @@ export const columnPengabdian = (): ColumnDef<PengabdianDosen>[] => {
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>,
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "action",
@@ -27,34 +34,34 @@ export const columnPengabdian = (): ColumnDef<PengabdianDosen>[] => {
               href={`${ROUTE.DASHBOARD}/kaprodi/pengabdian/${row.original.id}`}
               className={cn(
                 buttonVariants({ variant: "outline", size: "icon" }),
-                "border-cyan-500 text-cyan-500 hover:bg-cyan-500 hover:text-primary-foreground",
+                "border-cyan-500 text-cyan-500 hover:bg-cyan-500 hover:text-primary-foreground"
               )}
             >
               <InfoIcon />
             </Link>
           </Tooltip>
         )
-      },
+      }
     },
     {
       id: "title",
       accessorKey: "title",
-      header: "Judul Pengabdian",
+      header: "Judul Pengabdian"
     },
     {
       id: "leader",
       accessorKey: "leader",
-      header: "Penanggung Jawab",
+      header: "Penanggung Jawab"
     },
     {
       id: "academic_year",
       accessorKey: "academic_year",
-      header: "Tahun Akademik",
+      header: "Tahun Akademik"
     },
     {
       id: "created_date",
       accessorKey: "created_date",
-      header: "tanggal dibuat",
+      header: "tanggal dibuat"
     },
     {
       accessorKey: "status",
@@ -66,13 +73,13 @@ export const columnPengabdian = (): ColumnDef<PengabdianDosen>[] => {
           header: "Kaprodi",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.kaprodi} />
-          ),
+          )
         },
         {
           id: "status_dppm",
           accessorKey: "status_dppm",
           header: "Dppm",
-          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />,
+          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />
         },
         {
           id: "status_keuangan",
@@ -80,9 +87,9 @@ export const columnPengabdian = (): ColumnDef<PengabdianDosen>[] => {
           header: "Keuangan",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.keuangan} />
-          ),
-        },
-      ],
-    },
+          )
+        }
+      ]
+    }
   ]
 }

--- a/src/modules/kaprodi/feature/publikasi/components/column-publikasi.tsx
+++ b/src/modules/kaprodi/feature/publikasi/components/column-publikasi.tsx
@@ -20,13 +20,20 @@ interface columnPublikasiProps {
 
 export const columnPublikasi = ({
   pubilkasi,
-  refetch,
+  refetch
 }: columnPublikasiProps): ColumnDef<PublikasiKaprodi>[] => {
   return [
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>,
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "action",
@@ -43,11 +50,11 @@ export const columnPublikasi = ({
           },
           onError: err => {
             toast.error(err.response?.data.message)
-          },
+          }
         })
 
         const data = pubilkasi.find(
-          publikasi => publikasi.id === row.original.id,
+          publikasi => publikasi.id === row.original.id
         )
 
         return (
@@ -63,7 +70,7 @@ export const columnPublikasi = ({
               <div className='flex flex-col gap-4 tracking-wide'>
                 {[
                   row.original.status.kaprodi,
-                  row.original.status.dppm,
+                  row.original.status.dppm
                 ].includes("rejected") && (
                   <div className='rounded-lg border border-red-500 px-4 py-2 text-red-500'>
                     <p className='text-sm capitalize'>
@@ -117,7 +124,7 @@ export const columnPublikasi = ({
                     <span className='font-medium'>Tanggal Publikasi:</span>
                     {data?.tanggal_publikasi
                       ? format(new Date(data?.tanggal_publikasi), "PPP", {
-                          locale: id,
+                          locale: id
                         })
                       : "-"}
                   </p>
@@ -140,7 +147,7 @@ export const columnPublikasi = ({
                   href={data?.link_publikasi as string}
                   className={cn(
                     buttonVariants({ variant: "default" }),
-                    "capitalize",
+                    "capitalize"
                   )}
                   target='_blank'
                 >
@@ -165,15 +172,15 @@ export const columnPublikasi = ({
               )}
           </span>
         )
-      },
+      }
     },
     {
       accessorKey: "judul",
-      header: "Judul Pengabdian",
+      header: "Judul Pengabdian"
     },
     {
       accessorKey: "author",
-      header: "Penulis",
+      header: "Penulis"
     },
     {
       accessorKey: "tanggal_publikasi",
@@ -181,15 +188,15 @@ export const columnPublikasi = ({
       cell: ({ row }) => {
         const date = new Date(row.original.tanggal_publikasi)
         return <span>{format(date, "PPP", { locale: id })}</span>
-      },
+      }
     },
     {
       accessorKey: "tahun",
-      header: "Tahun",
+      header: "Tahun"
     },
     {
       accessorKey: "jurnal",
-      header: "Jurnal",
+      header: "Jurnal"
     },
     {
       accessorKey: "status",
@@ -201,13 +208,13 @@ export const columnPublikasi = ({
           header: "Kaprodi",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.kaprodi} />
-          ),
+          )
         },
         {
           id: "status_dppm",
           accessorKey: "status_dppm",
           header: "Dppm",
-          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />,
+          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />
         },
         {
           id: "status_keuangan",
@@ -215,9 +222,9 @@ export const columnPublikasi = ({
           header: "Keuangan",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.keuangan} />
-          ),
-        },
-      ],
-    },
+          )
+        }
+      ]
+    }
   ]
 }

--- a/src/modules/keuangan/feature/penelitian/components/column-penelitian.tsx
+++ b/src/modules/keuangan/feature/penelitian/components/column-penelitian.tsx
@@ -13,7 +13,14 @@ export const columnPenelitian = (): ColumnDef<PenelitianDosen>[] => {
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>,
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "action",
@@ -27,34 +34,34 @@ export const columnPenelitian = (): ColumnDef<PenelitianDosen>[] => {
               href={`${ROUTE.DASHBOARD}/keuangan/penelitian/${row.original.id}`}
               className={cn(
                 buttonVariants({ variant: "outline", size: "icon" }),
-                "border-cyan-500 text-cyan-500 hover:bg-cyan-500 hover:text-primary-foreground",
+                "border-cyan-500 text-cyan-500 hover:bg-cyan-500 hover:text-primary-foreground"
               )}
             >
               <InfoIcon />
             </Link>
           </Tooltip>
         )
-      },
+      }
     },
     {
       id: "title",
       accessorKey: "title",
-      header: "Judul Penelitian",
+      header: "Judul Penelitian"
     },
     {
       id: "leader",
       accessorKey: "leader",
-      header: "Penanggung Jawab",
+      header: "Penanggung Jawab"
     },
     {
       id: "academic_year",
       accessorKey: "academic_year",
-      header: "Tahun Akademik",
+      header: "Tahun Akademik"
     },
     {
       id: "created_date",
       accessorKey: "created_date",
-      header: "tanggal dibuat",
+      header: "tanggal dibuat"
     },
     {
       accessorKey: "status",
@@ -66,13 +73,13 @@ export const columnPenelitian = (): ColumnDef<PenelitianDosen>[] => {
           header: "Kaprodi",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.kaprodi} />
-          ),
+          )
         },
         {
           id: "status_dppm",
           accessorKey: "status_dppm",
           header: "Dppm",
-          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />,
+          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />
         },
         {
           id: "status_keuangan",
@@ -80,9 +87,9 @@ export const columnPenelitian = (): ColumnDef<PenelitianDosen>[] => {
           header: "Keuangan",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.keuangan} />
-          ),
-        },
-      ],
-    },
+          )
+        }
+      ]
+    }
   ]
 }

--- a/src/modules/keuangan/feature/pengabdian/components/column-pengabdian.tsx
+++ b/src/modules/keuangan/feature/pengabdian/components/column-pengabdian.tsx
@@ -13,7 +13,14 @@ export const columnPengabdian = (): ColumnDef<PengabdianDosen>[] => {
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>,
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "action",
@@ -27,34 +34,34 @@ export const columnPengabdian = (): ColumnDef<PengabdianDosen>[] => {
               href={`${ROUTE.DASHBOARD}/keuangan/pengabdian/${row.original.id}`}
               className={cn(
                 buttonVariants({ variant: "outline", size: "icon" }),
-                "border-cyan-500 text-cyan-500 hover:bg-cyan-500 hover:text-primary-foreground",
+                "border-cyan-500 text-cyan-500 hover:bg-cyan-500 hover:text-primary-foreground"
               )}
             >
               <InfoIcon />
             </Link>
           </Tooltip>
         )
-      },
+      }
     },
     {
       id: "title",
       accessorKey: "title",
-      header: "Judul Pengabdian",
+      header: "Judul Pengabdian"
     },
     {
       id: "leader",
       accessorKey: "leader",
-      header: "Penanggung Jawab",
+      header: "Penanggung Jawab"
     },
     {
       id: "academic_year",
       accessorKey: "academic_year",
-      header: "Tahun Akademik",
+      header: "Tahun Akademik"
     },
     {
       id: "created_date",
       accessorKey: "created_date",
-      header: "tanggal dibuat",
+      header: "tanggal dibuat"
     },
     {
       accessorKey: "status",
@@ -66,13 +73,13 @@ export const columnPengabdian = (): ColumnDef<PengabdianDosen>[] => {
           header: "Kaprodi",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.kaprodi} />
-          ),
+          )
         },
         {
           id: "status_dppm",
           accessorKey: "status_dppm",
           header: "Dppm",
-          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />,
+          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />
         },
         {
           id: "status_keuangan",
@@ -80,9 +87,9 @@ export const columnPengabdian = (): ColumnDef<PengabdianDosen>[] => {
           header: "Keuangan",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.keuangan} />
-          ),
-        },
-      ],
-    },
+          )
+        }
+      ]
+    }
   ]
 }

--- a/src/modules/keuangan/feature/publikasi/components/column-publikasi.tsx
+++ b/src/modules/keuangan/feature/publikasi/components/column-publikasi.tsx
@@ -20,13 +20,20 @@ interface columnPublikasiProps {
 
 export const columnPublikasi = ({
   pubilkasi,
-  refetch,
+  refetch
 }: columnPublikasiProps): ColumnDef<PublikasiKeuangan>[] => {
   return [
     {
       id: "no",
       header: "No",
-      cell: ({ row }) => <div>{row.index + 1}</div>,
+      cell: ({ row, table }) => {
+        const page = table.getState().pagination.pageIndex
+        const pageSize = table.getState().pagination.pageSize
+        const start = page * pageSize + 1
+        const end = start + row.index
+
+        return <div>{end}</div>
+      }
     },
     {
       id: "action",
@@ -43,11 +50,11 @@ export const columnPublikasi = ({
           },
           onError: err => {
             toast.error(err.response?.data.message)
-          },
+          }
         })
 
         const data = pubilkasi.find(
-          publikasi => publikasi.id === row.original.id,
+          publikasi => publikasi.id === row.original.id
         )
 
         return (
@@ -63,7 +70,7 @@ export const columnPublikasi = ({
               <div className='flex flex-col gap-4 tracking-wide'>
                 {[
                   row.original.status.kaprodi,
-                  row.original.status.dppm,
+                  row.original.status.dppm
                 ].includes("rejected") && (
                   <div className='rounded-lg border border-red-500 px-4 py-2 text-red-500'>
                     <p className='text-sm capitalize'>
@@ -117,7 +124,7 @@ export const columnPublikasi = ({
                     <span className='font-medium'>Tanggal Publikasi:</span>
                     {data?.tanggal_publikasi
                       ? format(new Date(data?.tanggal_publikasi), "PPP", {
-                          locale: id,
+                          locale: id
                         })
                       : "-"}
                   </p>
@@ -140,7 +147,7 @@ export const columnPublikasi = ({
                   href={data?.link_publikasi as string}
                   className={cn(
                     buttonVariants({ variant: "default" }),
-                    "capitalize",
+                    "capitalize"
                   )}
                   target='_blank'
                 >
@@ -164,15 +171,15 @@ export const columnPublikasi = ({
               )}
           </span>
         )
-      },
+      }
     },
     {
       accessorKey: "judul",
-      header: "Judul Pengabdian",
+      header: "Judul Pengabdian"
     },
     {
       accessorKey: "author",
-      header: "Penulis",
+      header: "Penulis"
     },
     {
       accessorKey: "tanggal_publikasi",
@@ -180,15 +187,15 @@ export const columnPublikasi = ({
       cell: ({ row }) => {
         const date = new Date(row.original.tanggal_publikasi)
         return <span>{format(date, "PPP", { locale: id })}</span>
-      },
+      }
     },
     {
       accessorKey: "tahun",
-      header: "Tahun",
+      header: "Tahun"
     },
     {
       accessorKey: "jurnal",
-      header: "Jurnal",
+      header: "Jurnal"
     },
     {
       accessorKey: "status",
@@ -200,13 +207,13 @@ export const columnPublikasi = ({
           header: "Kaprodi",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.kaprodi} />
-          ),
+          )
         },
         {
           id: "status_dppm",
           accessorKey: "status_dppm",
           header: "Dppm",
-          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />,
+          cell: ({ row }) => <StatusBadge status={row.original.status.dppm} />
         },
         {
           id: "status_keuangan",
@@ -214,9 +221,9 @@ export const columnPublikasi = ({
           header: "Keuangan",
           cell: ({ row }) => (
             <StatusBadge status={row.original.status.keuangan} />
-          ),
-        },
-      ],
-    },
+          )
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Components

The changes modify the row numbering logic in table components to properly account for pagination. Instead of using just row.index + 1, the calculation now considers the current page and page size to maintain consistent numbering across paginated data.

This affects multiple components across different modules including dosen, penelitian, pengabdian, publikasi, and others. The new implementation calculates the row number based on page index and page size to ensure correct numbering when navigating between pages.